### PR TITLE
feat: validation exception handler

### DIFF
--- a/app/Exceptions/Handler.ts
+++ b/app/Exceptions/Handler.ts
@@ -1,15 +1,23 @@
 import ApiException from "./ApiException";
 import { Handler as ExceptionHandler, HttpException } from "@lunoxjs/core";
 import { Response } from "@lunoxjs/core/facades";
+import { ValidationException } from "@lunoxjs/validation";
 
 class Handler extends ExceptionHandler {
-  protected dontReport = [];
+  protected dontReport = [ValidationException];
 
   register() {
     this.reportable(ApiException, (e) => {
       if (e.status >= 500) {
         console.log("API Error", e);
       }
+    });
+
+    this.renderable(ValidationException, (e)=>{
+      return Response.make({
+        message: e.message,
+        errors: e.errors()
+      }, e.status);
     });
 
     this.renderable(ApiException, (e) => {


### PR DESCRIPTION
This PR add handler for ValidationException from `@lunoxjs/validation`. So it will return appropriate response and status when validation fail.
